### PR TITLE
SMWS-3: Add Support for Multiple XPaths in replaceCasks Function

### DIFF
--- a/content.js
+++ b/content.js
@@ -211,16 +211,20 @@ const codes = {
 
 function replaceCasks()
 {
-  var casks = document.getElementsByClassName('caskNo');
+  var elementNames = ['caskNo', 'anotherClass', 'yetAnotherClass']; // Add more class names as needed
   const regex = /cask no\. (?<caskid>[A-Z]*[0-9]+)\.[0-9]/i;
-  for (var i = 0, l = casks.length; i < l; i++) {
-    it = casks[i].innerText;
-    matches = it.match(regex).groups;
-    if(matches !=null){
-      name = codes[matches.caskid];
-      casks[i].innerText = it + " (" + name + ")";
+  
+  elementNames.forEach(function(className) {
+    var casks = document.getElementsByClassName(className);
+    for (var i = 0, l = casks.length; i < l; i++) {
+      it = casks[i].innerText;
+      matches = it.match(regex).groups;
+      if(matches !=null){
+        name = codes[matches.caskid];
+        casks[i].innerText = it + " (" + name + ")";
+      }
     }
-  }
+  });
 }
 
 // wait a bit - sometimes smws does dynamic loading

--- a/content.js
+++ b/content.js
@@ -220,8 +220,8 @@ function replaceCasks()
       it = casks[i].innerText;
       matches = it.match(regex).groups;
       if(matches !=null){
-        name = codes[matches.caskid];
-        casks[i].innerText = it + " (" + name + ")";
+        distillery_name = codes[matches.caskid];
+        casks[i].innerText = it + " (" + distillery_name + ")";
       }
     }
   });


### PR DESCRIPTION
### Overview
This pull request addresses the issue of hardcoded element names in the `replaceCasks` function. Previously, the function only searched for elements with the class name `caskNo`. This update allows the function to search through a list of element names, making it more flexible and extensible.

### Key Changes
- Introduced an array `elementNames` containing multiple class names to search for, including `caskNo`, `anotherClass`, and `yetAnotherClass`.
- Updated the `replaceCasks` function to iterate through each class name in the `elementNames` array and perform the same operations as before.

### Impact
- The changes make the `replaceCasks` function more versatile by allowing it to handle multiple class names.
- No other parts of the codebase are impacted by this change as the core functionality remains the same.

### Context
The issue was identified due to the limitation of the function only handling a single class name. This update resolves that limitation by making the function capable of handling multiple class names, thereby improving its utility and flexibility.